### PR TITLE
Servicewell: Establish Servicewell Identity of Fork

### DIFF
--- a/build/ServicewellBuild/build-tool.yml
+++ b/build/ServicewellBuild/build-tool.yml
@@ -1,0 +1,67 @@
+trigger:
+- github/public-main
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  buildConfiguration: 'Release'
+  baseVersion: '0.9.0-preview'
+  packageVersion: '$(baseVersion)-build$(Build.BuildNumber)'
+  toolProjectPath: 'src/Microsoft.Health.Fhir.Liquid.Converter.Tool'
+  outputDir: '$(Build.ArtifactStagingDirectory)/nuget'
+
+steps:
+- task: UseDotNet@2
+  inputs:
+    packageType: sdk
+    version: '8.x'
+
+- script: |
+    echo "Build.BuildNumber: $(Build.BuildNumber)"
+    echo "baseVersion: $(baseVersion)"
+    echo "packageVersion: $(packageVersion)"
+  displayName: 'Debug: Version Variables'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Restore'
+  inputs:
+    command: 'restore'
+    projects: '$(toolProjectPath)/*.csproj'
+    feedsToUse: 'config'
+    nugetConfigPath: '$(Build.SourcesDirectory)/nuget.servicewell.config' # nuget.servicewell.config is the custom NuGet config used for CI builds
+    restoreArguments: '--disable-parallel'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build'
+  inputs:
+    command: 'build'
+    projects: '$(toolProjectPath)/*.csproj'
+    arguments: '--configuration $(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish tool project'
+  inputs:
+    command: publish
+    projects: '$(toolProjectPath)/*.csproj'
+    arguments: '--configuration $(buildConfiguration) --output $(Build.SourcesDirectory)/bin/publish'
+    publishWebProjects: false
+    zipAfterPublish: false
+    nobuild: true
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack tool project'
+  inputs:
+    command: custom
+    custom: pack
+    projects: '$(toolProjectPath)/*.csproj'
+    arguments: >
+      --configuration $(buildConfiguration)
+      --output $(outputDir)
+      --no-build
+      -p:NuspecProperties="version=$(packageVersion)"
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(outputDir)'
+    ArtifactName: 'nuget-package'

--- a/build/ServicewellBuild/publish-tool.yml
+++ b/build/ServicewellBuild/publish-tool.yml
@@ -1,0 +1,49 @@
+name: PublishToolToNuGet
+trigger: none  # Manual only
+
+pr: none       # No PR trigger
+
+variables:
+  buildConfiguration: 'Release'
+  outputDir: '$(Build.ArtifactStagingDirectory)/nuget'
+
+resources:
+  pipelines:
+    - pipeline: buildToolPipeline
+      source: ServicewellFhirLiquidToolBuild
+      trigger: none              # manual only
+
+stages:
+- stage: PushToNuGet
+  displayName: 'Publish NuGet Package'
+  jobs:
+  - job: Push
+    displayName: 'Push .nupkg to nuget.org'
+    pool:
+      vmImage: 'windows-latest'
+    variables:
+      NUGET_SOURCE: 'https://api.nuget.org/v3/index.json'
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download NuGet Artifact from Pipeline Run'
+      inputs:
+        buildType: 'specific'
+        project: '$(System.TeamProject)'
+        definition: 'ServicewellFhirLiquidToolBuild'
+        runVersion: 'latest'
+        artifactName: 'nuget-package'
+        targetPath: '$(outputDir)'
+
+    - script: |
+        echo Listing contents of: "$(outputDir)"
+        dir "$(outputDir)"
+      displayName: 'List package(s) to publish'
+
+    - task: NuGetCommand@2
+      displayName: 'Push .nupkg to NuGet.org'
+      inputs:
+        command: push
+        packagesToPush: '$(outputDir)\Servicewell.Fhir.Liquid.Converter.Tool*.nupkg'    
+        nuGetFeedType: external
+        publishFeedCredentials: 'NuGetOrgServicewell'  # name of your NuGet.org service connection

--- a/nuget.servicewell.config
+++ b/nuget.servicewell.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<!-- nuget.servicewell.config is the custom NuGet config used for CI builds and public publishing.
+It replaces the upstream config to properly resolve Microsoft.Extensions.* from nuget.org
+while routing Microsoft.Health.* to Microsoft Health OSS.
+-->
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
+  <packageSources>
+  	<!-- When <clear /> is present, previously defined sources are ignored -->		
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
+  </packageSources>
+<packageSourceMapping>
+    <packageSource key="Microsoft Health OSS">
+      <package pattern="Microsoft.Health.*" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(LatestFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <NuspecFile>Microsoft.Health.Fhir.Liquid.Converter.Tool.nuspec</NuspecFile>
+    <NuspecFile>Servicewell.Fhir.Liquid.Converter.Tool.nuspec</NuspecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Readme.md
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Readme.md
@@ -1,0 +1,7 @@
+﻿# FHIR Liquid Converter
+
+An open source tool by Service Well AB for converting healthcare data to HL7 FHIR using Liquid templates, with extended support for terminology translation and FHIR Implementation Guides integration.      
+
+This tool is a Servicewell-maintained fork of [Microsoft's FHIR Converter](https://github.com/microsoft/FHIR-Converter).
+
+See full documentation at [https://github.com/servicewell/FHIR-Liquid-Converter](https://github.com/servicewell/FHIR-Liquid-Converter).

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Servicewell.Fhir.Liquid.Converter.Tool.nuspec
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Servicewell.Fhir.Liquid.Converter.Tool.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Servicewell.Fhir.Liquid.Converter.Tool</id>
+    <version>$version$</version>
+    <authors>Servicewell</authors>
+    <license type="expression">Apache-2.0</license>
+    <copyright>Copyright © Servicewell</copyright>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      An open source tool by Service Well AB for converting healthcare data to HL7 FHIR using Liquid templates,
+      with extended support for terminology translation and FHIR Implementation Guides integration.      
+    </description>
+    <readme>Readme.md</readme>
+    <projectUrl>https://github.com/servicewell/FHIR-Liquid-Converter</projectUrl>
+    <repository type="git" url="https://github.com/servicewell/FHIR-Liquid-Converter" />
+    <contentFiles>
+      <files include="any/net8.0/**/*.*" buildAction="Content" copyToOutput="true" />
+    </contentFiles>
+  </metadata>
+  <files>
+    <file src="Readme.md" target="." />
+    <file src="..\..\bin\publish\**" target="contentFiles\any\net8.0" />
+  </files>
+</package>


### PR DESCRIPTION
This PR formally separates the Servicewell-maintained fork from the original Microsoft FHIR Converter by:

* Renaming the NuGet package to Servicewell.Fhir.Liquid.Converter.Tool
* Adding a NuGet-compatible README.md to clarify purpose and usage
* Adding dedicated CI pipelines for:
  * Building and packaging the tool (build-tool.yml)
  * Manually publishing packages to NuGet (publish-tool.yml)
