### PR TITLE
Add Fhir package management support and optional persistence to CLI and core libraries

### DIFF
--- a/Fhir.Liquid.Converter.sln
+++ b/Fhir.Liquid.Converter.sln
@@ -29,6 +29,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Data", "Data", "{D00221FC-4
 		data\Templates\Tirsv1\Test.liquid = data\Templates\Tirsv1\Test.liquid
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FLC.PackageManagement", "src\FLC.PackageManagement\FLC.PackageManagement.csproj", "{13C4A4A5-219E-A881-F520-DEB895180596}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FLC.PackageManagement.Persistence", "src\FLC.PackageManagement.Persistence\FLC.PackageManagement.Persistence.csproj", "{2E659798-CAF1-D237-98D3-D1C5CD8714B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +67,14 @@ Global
 		{C4049E7B-7977-4691-BE86-4BD7E3E8C401}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4049E7B-7977-4691-BE86-4BD7E3E8C401}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4049E7B-7977-4691-BE86-4BD7E3E8C401}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13C4A4A5-219E-A881-F520-DEB895180596}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13C4A4A5-219E-A881-F520-DEB895180596}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13C4A4A5-219E-A881-F520-DEB895180596}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13C4A4A5-219E-A881-F520-DEB895180596}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E659798-CAF1-D237-98D3-D1C5CD8714B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E659798-CAF1-D237-98D3-D1C5CD8714B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E659798-CAF1-D237-98D3-D1C5CD8714B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E659798-CAF1-D237-98D3-D1C5CD8714B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/FLC.PackageManagement.Persistence/DbFactory/IDbConnectionFactory.cs
+++ b/src/FLC.PackageManagement.Persistence/DbFactory/IDbConnectionFactory.cs
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Data;
+
+namespace FLC.PackageManagement.Persistence.DbFactory;
+
+public interface IDbConnectionFactory
+{
+    IDbConnection CreateConnection();
+}

--- a/src/FLC.PackageManagement.Persistence/DbFactory/SqlServerConnectionFactory.cs
+++ b/src/FLC.PackageManagement.Persistence/DbFactory/SqlServerConnectionFactory.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Data;
+using Microsoft.Data.SqlClient;
+
+namespace FLC.PackageManagement.Persistence.DbFactory;
+
+public class SqlServerConnectionFactory(string connectionString)
+    : IDbConnectionFactory
+{
+    public IDbConnection CreateConnection()
+    {
+        return new SqlConnection(connectionString);
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/DbFactory/SqliteConnectionFactory.cs
+++ b/src/FLC.PackageManagement.Persistence/DbFactory/SqliteConnectionFactory.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Data;
+using Microsoft.Data.Sqlite;
+
+namespace FLC.PackageManagement.Persistence.DbFactory;
+
+public class SqliteConnectionFactory(string connectionString)
+    : IDbConnectionFactory
+{
+    public IDbConnection CreateConnection()
+    {
+        return new SqliteConnection(connectionString);
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Exceptions/DatabaseException.cs
+++ b/src/FLC.PackageManagement.Persistence/Exceptions/DatabaseException.cs
@@ -1,0 +1,10 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Persistence.Exceptions;
+
+public class DatabaseException(string message, Exception inner = null)
+    : Exception(message, inner)
+{
+}

--- a/src/FLC.PackageManagement.Persistence/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/FLC.PackageManagement.Persistence/Extensions/DatabaseInitializationExtensions.cs
@@ -1,0 +1,24 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Persistence.Initialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FLC.PackageManagement.Persistence.Extensions;
+
+public static class DatabaseInitializationExtensions
+{
+    // Initializes the database by resolving IDatabaseInitializer from a scoped service provider.
+    // Intended for CLI applications that do not use IHostedService.
+    public static async Task InitializePackageManagementDatabaseAsync(
+        this IHost host,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = host.Services.CreateScope();
+        var initializer = scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>();
+
+        await initializer.InitializeAsync(cancellationToken);
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Extensions/PersistenceServiceCollectionExtensions.cs
+++ b/src/FLC.PackageManagement.Persistence/Extensions/PersistenceServiceCollectionExtensions.cs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Persistence.DbFactory;
+using FLC.PackageManagement.Persistence.Initialization;
+using FLC.PackageManagement.Persistence.Interfaces;
+using FLC.PackageManagement.Persistence.Repositories;
+using FLC.PackageManagement.Persistence.Services;
+using FLC.PackageManagement.Services.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FLC.PackageManagement.Persistence.Extensions;
+
+public static class PersistenceServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers database persistence for PackageManagement (connection factory, repositories and IDatabaseInitializer).
+    /// The PackageManagement.Persistence module adds database persistence for FHIR package contents, including Implementation Guides, Libraries, and StructureMaps.
+    /// When a package is imported, meta data from artifacts are extracted and written to the database so that conversion operations can access them without beeing depending on path to disk for Liquid templates.
+    /// This enables consistent, centralized storage of all FHIR transformation assets and improves runtime reliability and deployment flexibility.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This extension assumes that <c>AddPackageManagement()</c> has already been called.
+    /// It reads its configuration from the <c>PackageManagement</c> section and expects at least:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// <c>PackageManagement:Database:Provider</c> – database provider name, e.g. <c>SQLite</c> or <c>SQLServer</c>.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <c>PackageManagement:ConnectionStrings:&lt;Provider&gt;</c> – matching connection string, e.g.
+    /// <c>PackageManagement:ConnectionStrings:SQLite</c>.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// Example <c>appsettings.json</c> section:
+    /// </para>
+    /// <code language="json">
+    /// "PackageManagement": {
+    ///   "Database": {
+    ///     "Provider": "SQLite",
+    ///     "InitializeAtStartup": true
+    ///   },
+    ///   "ConnectionStrings": {
+    ///     "SQLite": "Data Source=./database/flc-transformer.db;Cache=Shared;Foreign Keys=True"
+    ///   }
+    /// }
+    /// </code>
+    /// <para>
+    /// Equivalent configuration using environment variables:
+    /// </para>
+    /// <code>
+    /// PackageManagement__Database__Provider=SQLite
+    /// PackageManagement__Database__InitializeAtStartup=true
+    /// PackageManagement__ConnectionStrings__SQLite=Data Source=./database/flc-transformer.db;Cache=Shared;Foreign Keys=True
+    /// </code>
+    /// </remarks>
+    /// <param name="services">The service collection to add persistence services to.</param>
+    /// <param name="config">Application configuration used to resolve PackageManagement settings.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when required configuration values (provider or connection string) are missing or invalid.
+    /// </exception>
+    public static IServiceCollection AddPackageManagementPersistence(this IServiceCollection services, IConfiguration config)
+    {
+        var provider = config["PackageManagement:Database:Provider"];
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            throw new InvalidOperationException("Missing database provider (PackageManagement:Database:Provider).");
+        }
+
+        var connectionString = config[$"PackageManagement:ConnectionStrings:{provider}"];
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException($"Missing connection string (PackageManagement:ConnectionStrings:{provider}).");
+        }
+
+        bool initializeAtStartup = config.GetValue("PackageManagement:Database:InitializeAtStartup", true);
+        if (provider.Equals("SQLServer", StringComparison.OrdinalIgnoreCase))
+        {
+            services.AddSingleton<IDbConnectionFactory>(new SqlServerConnectionFactory(connectionString));
+
+            // ToDo: Add SqlServerDatabaseInitializer
+            if (initializeAtStartup)
+            {
+                throw new InvalidOperationException($"Provider '{provider}' cannot be initialized at startup. Create database and tables manually, then set PackageManagement:Database:InitializeAtStartup = false.");
+            }
+        }
+        else if (provider.Equals("SQLite", StringComparison.OrdinalIgnoreCase))
+        {
+            services.AddSingleton<IDbConnectionFactory>(new SqliteConnectionFactory(connectionString));
+            services.AddSingleton<IDatabaseInitializer, SqliteDatabaseInitializer>();
+
+            if (initializeAtStartup)
+            {
+                services.AddHostedService<SqliteInitializer>();
+            }
+        }
+        else
+        {
+            throw new InvalidOperationException($"Invalid database provider {provider}. Allowed are SQLite and SQLServer");
+        }
+
+        services.AddScoped<IFlcImplementationGuideRepository, FlcImplementationGuideRepository>();
+        services.AddScoped<IFlcStructureMapRepository, FlcStructureMapRepository>();
+        services.AddScoped<IFlcLibraryRepository, FlcLibraryRepository>();
+        services.AddScoped<IPersistenceService, PersistenceService>();
+
+        return services;
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/FLC.PackageManagement.Persistence.csproj
+++ b/src/FLC.PackageManagement.Persistence/FLC.PackageManagement.Persistence.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Scripts\SQLite\001_CreateTables.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Scripts\SQLite\001_CreateTables.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FLC.PackageManagement\FLC.PackageManagement.csproj" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <NoWarn>SA1201;$(NoWarn)</NoWarn> <!-- Used version of style cop does not handle primary constructors -->
+  </PropertyGroup>
+  
+</Project>

--- a/src/FLC.PackageManagement.Persistence/Initialization/IDatabaseInitializer.cs
+++ b/src/FLC.PackageManagement.Persistence/Initialization/IDatabaseInitializer.cs
@@ -1,0 +1,10 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Persistence.Initialization;
+
+public interface IDatabaseInitializer
+{
+    Task InitializeAsync(CancellationToken ct);
+}

--- a/src/FLC.PackageManagement.Persistence/Initialization/SqliteDatabaseFileHelper.cs
+++ b/src/FLC.PackageManagement.Persistence/Initialization/SqliteDatabaseFileHelper.cs
@@ -1,0 +1,48 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+
+namespace FLC.PackageManagement.Persistence.Initialization;
+
+public static class SqliteDatabaseFileHelper
+{
+    public static void EnsureSqliteFolder(IConfiguration configuration, string contentRootPath)
+    {
+        var connectionString = configuration["PackageManagement:ConnectionStrings:SQLite"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException("SQLite connection string not configured (PackageManagement:ConnectionStrings:SQLite).");
+        }
+
+        var sb = new SqliteConnectionStringBuilder(connectionString);
+        var dataSource = (sb.DataSource ?? string.Empty).Trim();
+
+        // ignore in-memory databases
+        if (dataSource.Equals(":memory:", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string resolvedPath;
+        if (dataSource.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+        {
+            // strip "file:" and any query
+            var pathPart = dataSource.Substring(5).Split('?', '#')[0];
+            resolvedPath = Path.IsPathRooted(pathPart)
+                ? pathPart
+                : Path.GetFullPath(Path.Combine(contentRootPath, pathPart));
+        }
+        else
+        {
+            // plain path
+            resolvedPath = Path.IsPathRooted(dataSource)
+                ? dataSource
+                : Path.GetFullPath(Path.Combine(contentRootPath, dataSource));
+        }
+
+        var dir = Path.GetDirectoryName(resolvedPath);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Initialization/SqliteDatabaseInitializer.cs
+++ b/src/FLC.PackageManagement.Persistence/Initialization/SqliteDatabaseInitializer.cs
@@ -1,0 +1,67 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Data.Common;
+using System.Reflection;
+using Dapper;
+using FLC.PackageManagement.Persistence.DbFactory;
+using Microsoft.Extensions.Logging;
+
+namespace FLC.PackageManagement.Persistence.Initialization;
+
+public sealed class SqliteDatabaseInitializer : IDatabaseInitializer
+{
+    private readonly IDbConnectionFactory _dbConnectionFactory;
+    private readonly ILogger<SqliteDatabaseInitializer> _logger;
+
+    public SqliteDatabaseInitializer(IDbConnectionFactory dbConnectionFactory, ILogger<SqliteDatabaseInitializer> logger)
+    {
+        _dbConnectionFactory = dbConnectionFactory;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(CancellationToken ct)
+    {
+        _logger.LogInformation("Initializing SQLite database...");
+
+        using var connection = _dbConnectionFactory.CreateConnection();
+
+        if (connection is DbConnection dbConn)
+        {
+            await dbConn.OpenAsync(ct);
+        }
+        else
+        {
+            connection.Open();
+        }
+
+        // Pragmas recommended on open
+        await connection.ExecuteAsync("PRAGMA foreign_keys=ON;", commandTimeout: 30);
+        await connection.ExecuteAsync("PRAGMA journal_mode=WAL;", commandTimeout: 30);
+
+        // Load schema SQL (embedded resource)
+        var sql = await LoadEmbeddedSqlAsync("Scripts.SQLite.001_CreateTables.sql", ct);
+
+        await connection.ExecuteAsync(sql, commandTimeout: 60);
+
+        _logger.LogInformation("SQLite database initialized.");
+    }
+
+    private static async Task<string> LoadEmbeddedSqlAsync(string relativePath, CancellationToken ct)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var root = asm.GetName().Name; // Dynamiskt "FLC.PackageManagement.Persistence"
+
+        var fullResourceName = $"{root}.{relativePath}";
+
+        await using var stream = asm.GetManifestResourceStream(fullResourceName)
+            ?? throw new FileNotFoundException($"Embedded SQL not found: {fullResourceName}");
+
+        using var reader = new StreamReader(stream);
+        var sql = await reader.ReadToEndAsync();
+
+        ct.ThrowIfCancellationRequested();
+        return sql;
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Initialization/SqliteInitializer.cs
+++ b/src/FLC.PackageManagement.Persistence/Initialization/SqliteInitializer.cs
@@ -1,0 +1,31 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace FLC.PackageManagement.Persistence.Initialization;
+
+public class SqliteInitializer(
+                IConfiguration configuration,
+                IHostEnvironment hostEnvironment,
+                IDatabaseInitializer databaseInitializer,
+                ILogger<SqliteInitializer> logger)
+    : IHostedService
+{
+    public async Task StartAsync(CancellationToken ct)
+    {
+        logger.LogInformation("Starting database initialization...");
+
+        SqliteDatabaseFileHelper.EnsureSqliteFolder(configuration, hostEnvironment.ContentRootPath);
+
+        await databaseInitializer.InitializeAsync(ct);
+        logger.LogInformation("Database initialization completed.");
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+
+}

--- a/src/FLC.PackageManagement.Persistence/Interfaces/IFlcImplementationGuideRepository.cs
+++ b/src/FLC.PackageManagement.Persistence/Interfaces/IFlcImplementationGuideRepository.cs
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Persistence.Models;
+
+namespace FLC.PackageManagement.Persistence.Interfaces;
+
+public interface IFlcImplementationGuideRepository
+{
+    Task<int> InsertAsync(FlcImplementationGuide entity);
+
+    Task<FlcImplementationGuide> GetByIdAsync(int id);
+
+    Task<bool> UpdateAsync(FlcImplementationGuide entity);
+
+    Task<bool> DeleteAsync(int id);
+
+    Task<FlcImplementationGuide> GetByUrlAndVersionAsync(string url, string version);
+}

--- a/src/FLC.PackageManagement.Persistence/Interfaces/IFlcLibraryRepository.cs
+++ b/src/FLC.PackageManagement.Persistence/Interfaces/IFlcLibraryRepository.cs
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Persistence.Models;
+
+namespace FLC.PackageManagement.Persistence.Interfaces;
+
+public interface IFlcLibraryRepository
+{
+    Task<int> InsertAsync(FlcLibrary entity);
+
+    Task<FlcLibrary> GetByIdAsync(int id);
+
+    Task<bool> UpdateAsync(FlcLibrary entity);
+
+    Task<bool> DeleteAsync(int id);
+
+    Task<FlcLibrary> GetByUrlAndVersionAsync(string url, string version);
+}

--- a/src/FLC.PackageManagement.Persistence/Interfaces/IFlcStructureMapRepository.cs
+++ b/src/FLC.PackageManagement.Persistence/Interfaces/IFlcStructureMapRepository.cs
@@ -1,0 +1,35 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Persistence.Models;
+using FLC.PackageManagement.Persistence.Models.Custom;
+
+namespace FLC.PackageManagement.Persistence.Interfaces;
+
+public interface IFlcStructureMapRepository
+{
+    Task<int> InsertAsync(FlcStructureMap entity);
+
+    Task InsertAsync(IEnumerable<FlcStructureMap> entities);
+
+    Task<FlcStructureMap> GetByIdAsync(int id);
+
+    Task<FlcStructureMap> GetByUrlAndVersionAsync(string url, string version);
+
+    Task<bool> UpdateAsync(FlcStructureMap entity);
+
+    Task<bool> DeleteAsync(int id);
+
+    // Resolve templates by structureMapId
+    Task<StructureMapTemplateInfo> GetTemplateInfoByStructureMapIdAsync(int structureMapId);
+
+    // For Api
+    Task<ImplementationGuideStructureMapLibraryFlat> GetFlatByIdAsync(int structureMapId);
+
+    Task<ImplementationGuideStructureMapLibraryFlat> GetFlatByUrlAndVersionAsync(string url, string version);
+
+    Task<IReadOnlyList<ImplementationGuideStructureMapLibraryFlat>> GetFlatByImplementationGuideAsync(string implementationGuideUrl, string implementationGuideVersion);
+
+    Task<IReadOnlyList<ImplementationGuideStructureMapLibraryFlat>> GetAllFlatAsync();
+}

--- a/src/FLC.PackageManagement.Persistence/Interfaces/IHasTimestamps.cs
+++ b/src/FLC.PackageManagement.Persistence/Interfaces/IHasTimestamps.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Persistence.Interfaces;
+
+public interface IHasTimestamps
+{
+    DateTime CreatedAt { get; set; }
+
+    DateTime UpdatedAt { get; set; }
+
+    // Default implementation
+    public void SetInsertTimes() => CreatedAt = UpdatedAt = DateTime.UtcNow;
+
+    public void SetUpdateTimes() => UpdatedAt = DateTime.UtcNow;
+}

--- a/src/FLC.PackageManagement.Persistence/Mappers/PackageToEntityMapper.cs
+++ b/src/FLC.PackageManagement.Persistence/Mappers/PackageToEntityMapper.cs
@@ -1,0 +1,56 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Models;
+using FLC.PackageManagement.Persistence.Models;
+
+namespace FLC.PackageManagement.Persistence.Mappers;
+
+public static class PackageToEntityMapper
+{
+    public static FlcImplementationGuide MapToFlcImplementationGuide(PackageResult package)
+    {
+        return new FlcImplementationGuide
+        {
+            ImplementationGuideId = package.ImplementationGuideItem.Id,
+            Url = package.ImplementationGuideItem.Url,
+            Version = package.ImplementationGuideItem.Version,
+            PackageId = package.ImplementationGuideItem.PackageId,
+            ResourceJson = package.ImplementationGuideItem.Json,
+        };
+    }
+
+    public static FlcLibrary MapToFlcLibrary(PackageResult package, int implementationGuidId)
+    {
+        return new FlcLibrary
+        {
+            LibraryId = package.LibraryItem.Id,
+            Url = package.LibraryItem.Url,
+            Version = package.LibraryItem.Version,
+            FlcImplementationGuideId = implementationGuidId,
+            StorageRoot = package.LibraryItem.StorageRoot,
+
+            // Checksum = // TODO: Implement this if we want to use a checksum on the folder
+            ResourceJson = package.LibraryItem.Json,
+        };
+    }
+
+    public static IEnumerable<FlcStructureMap> MapToFlcStructureMaps(PackageResult package, int implementationGuidId, int libraryId)
+    {
+        return package.StructureMapItems.Select(sm => new FlcStructureMap
+        {
+            StructureMapId = sm.Id,
+            Url = sm.Url,
+            Version = sm.Version,
+            FlcImplementationGuideId = implementationGuidId,
+            Source = sm.Source,
+            SourceVersion = sm.SourceVersion,
+            Target = sm.Target,
+            TargetVersion = sm.TargetVersion,
+            FlcLibraryId = libraryId,
+            EntryTemplate = sm.EntryTemplate,
+            ResourceJson = sm.Json,
+        });
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Models/Custom/ImplementationGuideStructureMapLibraryFlat.cs
+++ b/src/FLC.PackageManagement.Persistence/Models/Custom/ImplementationGuideStructureMapLibraryFlat.cs
@@ -1,0 +1,26 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Persistence.Models.Custom;
+
+public sealed class ImplementationGuideStructureMapLibraryFlat
+{
+    public int FlcImplementationGuideId { get; set; }
+
+    public string ImplementationGuideUrl { get; set; } = string.Empty;
+
+    public string ImplementationGuideVersion { get; set; } = string.Empty;
+
+    public int FlcStructureMapId { get; set; }
+
+    public string StructureMapUrl { get; set; } = string.Empty;
+
+    public string StructureMapVersion { get; set; } = string.Empty;
+
+    public int FlcLibraryId { get; set; }
+
+    public string LibraryUrl { get; set; } = string.Empty;
+
+    public string LibraryVersion { get; set; } = string.Empty;
+}

--- a/src/FLC.PackageManagement.Persistence/Models/Custom/StructureMapTemplateInfo.cs
+++ b/src/FLC.PackageManagement.Persistence/Models/Custom/StructureMapTemplateInfo.cs
@@ -1,0 +1,14 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Persistence.Models.Custom;
+
+public sealed class StructureMapTemplateInfo
+{
+    public int FlcStructureMapId { get; set; }
+
+    public string EntryTemplate { get; set; } = string.Empty;
+
+    public string TemplatesRoot { get; set; } = string.Empty;
+}

--- a/src/FLC.PackageManagement.Persistence/Models/FlcImplementationGuide.cs
+++ b/src/FLC.PackageManagement.Persistence/Models/FlcImplementationGuide.cs
@@ -1,0 +1,29 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using Dapper.Contrib.Extensions;
+using FLC.PackageManagement.Persistence.Interfaces;
+
+namespace FLC.PackageManagement.Persistence.Models;
+
+[Table("flcImplementationGuide")]
+public sealed class FlcImplementationGuide : IHasTimestamps
+{
+    [Key]
+    public int Id { get; set; }
+
+    public string ImplementationGuideId { get; set; }
+
+    public string Url { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    public string PackageId { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public string ResourceJson { get; set; }
+}

--- a/src/FLC.PackageManagement.Persistence/Models/FlcLibrary.cs
+++ b/src/FLC.PackageManagement.Persistence/Models/FlcLibrary.cs
@@ -1,0 +1,33 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using Dapper.Contrib.Extensions;
+using FLC.PackageManagement.Persistence.Interfaces;
+
+namespace FLC.PackageManagement.Persistence.Models;
+
+[Table("flcLibrary")]
+public sealed class FlcLibrary : IHasTimestamps
+{
+    [Key]
+    public int Id { get; set; }
+
+    public string LibraryId { get; set; }
+
+    public string Url { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    public int FlcImplementationGuideId { get; set; }
+
+    public string StorageRoot { get; set; }
+
+    public byte[] Checksum { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public string ResourceJson { get; set; }
+}

--- a/src/FLC.PackageManagement.Persistence/Models/FlcStructureMap.cs
+++ b/src/FLC.PackageManagement.Persistence/Models/FlcStructureMap.cs
@@ -1,0 +1,41 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using Dapper.Contrib.Extensions;
+using FLC.PackageManagement.Persistence.Interfaces;
+
+namespace FLC.PackageManagement.Persistence.Models;
+
+[Table("flcStructureMap")]
+public sealed class FlcStructureMap : IHasTimestamps
+{
+    [Key]
+    public int Id { get; set; }
+
+    public string StructureMapId { get; set; }
+
+    public string Url { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    public int FlcImplementationGuideId { get; set; }
+
+    public string Source { get; set; }
+
+    public string SourceVersion { get; set; }
+
+    public string Target { get; set; }
+
+    public string TargetVersion { get; set; }
+
+    public int FlcLibraryId { get; set; }
+
+    public string EntryTemplate { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public string ResourceJson { get; set; }
+}

--- a/src/FLC.PackageManagement.Persistence/Repositories/DapperRepositoryBase.cs
+++ b/src/FLC.PackageManagement.Persistence/Repositories/DapperRepositoryBase.cs
@@ -1,0 +1,18 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Data;
+using FLC.PackageManagement.Persistence.DbFactory;
+
+namespace FLC.PackageManagement.Persistence.Repositories;
+
+public abstract class DapperRepositoryBase(IDbConnectionFactory factory)
+{
+    protected IDbConnection OpenConnection()
+    {
+        var connection = factory.CreateConnection();
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Repositories/FlcImplementationGuideRepository.cs
+++ b/src/FLC.PackageManagement.Persistence/Repositories/FlcImplementationGuideRepository.cs
@@ -1,0 +1,66 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using Dapper;
+using Dapper.Contrib.Extensions;
+using FLC.PackageManagement.Persistence.DbFactory;
+using FLC.PackageManagement.Persistence.Interfaces;
+using FLC.PackageManagement.Persistence.Models;
+
+namespace FLC.PackageManagement.Persistence.Repositories;
+
+public class FlcImplementationGuideRepository(IDbConnectionFactory factory)
+    : DapperRepositoryBase(factory), IFlcImplementationGuideRepository
+{
+    public async Task<int> InsertAsync(FlcImplementationGuide entity)
+    {
+        ((IHasTimestamps)entity).SetInsertTimes();
+
+        using var connection = OpenConnection();
+
+        return await connection.InsertAsync(entity);
+    }
+
+    public async Task<FlcImplementationGuide> GetByIdAsync(int id)
+    {
+        using var connection = OpenConnection();
+
+        return await connection.GetAsync<FlcImplementationGuide>(id);
+    }
+
+    public async Task<bool> UpdateAsync(FlcImplementationGuide entity)
+    {
+        ((IHasTimestamps)entity).SetUpdateTimes();
+
+        using var connection = OpenConnection();
+
+        return await connection.UpdateAsync(entity);
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        using var connection = OpenConnection();
+
+        return await connection.DeleteAsync(new FlcImplementationGuide { Id = id });
+    }
+
+    /// <summary>
+    /// Get one FlcImplementationGuide (filter on URL+Version)
+    /// Returnerar null om ingen match hittas.
+    /// </summary>
+    /// <param name="url">Implementation Guide URL</param>
+    /// <param name="version">Implementation Guide Version</param>
+    public async Task<FlcImplementationGuide> GetByUrlAndVersionAsync(string url, string version)
+    {
+        const string sql = """
+            SELECT * 
+            FROM flcImplementationGuide ig 
+            WHERE ig.Url = @Url AND ig.Version = @Version
+        """;
+
+        using var connection = OpenConnection();
+
+        return await connection.QueryFirstOrDefaultAsync<FlcImplementationGuide>(sql, new { Url = url, Version = version });
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Repositories/FlcLibraryRepository.cs
+++ b/src/FLC.PackageManagement.Persistence/Repositories/FlcLibraryRepository.cs
@@ -1,0 +1,66 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using Dapper;
+using Dapper.Contrib.Extensions;
+using FLC.PackageManagement.Persistence.DbFactory;
+using FLC.PackageManagement.Persistence.Interfaces;
+using FLC.PackageManagement.Persistence.Models;
+
+namespace FLC.PackageManagement.Persistence.Repositories;
+
+public class FlcLibraryRepository(IDbConnectionFactory factory)
+    : DapperRepositoryBase(factory), IFlcLibraryRepository
+{
+    public async Task<int> InsertAsync(FlcLibrary entity)
+    {
+        ((IHasTimestamps)entity).SetInsertTimes();
+
+        using var connection = OpenConnection();
+
+        return await connection.InsertAsync(entity);
+    }
+
+    public async Task<FlcLibrary> GetByIdAsync(int id)
+    {
+        using var connection = OpenConnection();
+
+        return await connection.GetAsync<FlcLibrary>(id);
+    }
+
+    public async Task<bool> UpdateAsync(FlcLibrary entity)
+    {
+        ((IHasTimestamps)entity).SetUpdateTimes();
+
+        using var connection = OpenConnection();
+
+        return await connection.UpdateAsync(entity);
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        using var connection = OpenConnection();
+
+        return await connection.DeleteAsync(new FlcLibrary { Id = id });
+    }
+
+    /// <summary>
+    /// Get one FlcLibrary (filter on URL+Version)
+    /// Returnerar null om ingen match hittas.
+    /// </summary>
+    /// <param name="url">FlcLibrary URL</param>
+    /// <param name="version">FlcLibrary Version</param>
+    public async Task<FlcLibrary> GetByUrlAndVersionAsync(string url, string version)
+    {
+        const string sql = """
+            SELECT * 
+            FROM flcLibrary l
+            WHERE l.Url = @Url AND l.Version = @Version
+        """;
+
+        using var connection = OpenConnection();
+
+        return await connection.QueryFirstOrDefaultAsync<FlcLibrary>(sql, new { Url = url, Version = version });
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Repositories/FlcStructureMapRepository.cs
+++ b/src/FLC.PackageManagement.Persistence/Repositories/FlcStructureMapRepository.cs
@@ -1,0 +1,237 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using Dapper;
+using Dapper.Contrib.Extensions;
+using FLC.PackageManagement.Persistence.DbFactory;
+using FLC.PackageManagement.Persistence.Interfaces;
+using FLC.PackageManagement.Persistence.Models;
+using FLC.PackageManagement.Persistence.Models.Custom;
+
+namespace FLC.PackageManagement.Persistence.Repositories;
+
+public class FlcStructureMapRepository(IDbConnectionFactory factory)
+    : DapperRepositoryBase(factory), IFlcStructureMapRepository
+{
+    public async Task<int> InsertAsync(FlcStructureMap entity)
+    {
+        ((IHasTimestamps)entity).SetInsertTimes();
+
+        using var connection = OpenConnection();
+
+        return await connection.InsertAsync(entity);
+    }
+
+    public async Task InsertAsync(IEnumerable<FlcStructureMap> entities)
+    {
+        using var connection = OpenConnection();
+
+        using var transaction = connection.BeginTransaction();
+        foreach (var entity in entities)
+        {
+            ((IHasTimestamps)entity).SetInsertTimes();
+            await connection.InsertAsync(entity, transaction);
+        }
+
+        transaction.Commit();
+    }
+
+    public async Task<FlcStructureMap> GetByIdAsync(int id)
+    {
+        using var connection = OpenConnection();
+
+        return await connection.GetAsync<FlcStructureMap>(id);
+    }
+
+    public async Task<bool> UpdateAsync(FlcStructureMap entity)
+    {
+        ((IHasTimestamps)entity).SetUpdateTimes();
+
+        using var connection = OpenConnection();
+
+        return await connection.UpdateAsync(entity);
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        using var connection = OpenConnection();
+
+        return await connection.DeleteAsync(new FlcStructureMap { Id = id });
+    }
+
+    /// <summary>
+    /// Get one FlcStructureMap (filter on URL+Version)
+    /// Return null if no match was found.
+    /// </summary>
+    /// <param name="url">StructureMap URL</param>
+    /// <param name="version">StructureMap Version</param>
+    public async Task<FlcStructureMap> GetByUrlAndVersionAsync(string url, string version)
+    {
+        const string sql = """
+            SELECT * 
+            FROM flcStructureMap sm 
+            WHERE sm.Url = @Url AND sm.Version = @Version
+        """;
+
+        using var connection = OpenConnection();
+
+        return await connection.QueryFirstOrDefaultAsync<FlcStructureMap>(sql, new { Url = url, Version = version });
+    }
+
+    /// <summary>
+    /// Get one StructureMap by id with included Ig and Library.
+    /// </summary>
+    /// <param name="structureMapId">Database id of StructureMap</param>
+    public async Task<ImplementationGuideStructureMapLibraryFlat> GetFlatByIdAsync(int structureMapId)
+    {
+        const string sql = """
+            SELECT 
+                ig.Id      AS FlcImplementationGuideId,
+                ig.Url     AS ImplementationGuideUrl,
+                ig.Version AS ImplementationGuideVersion,
+
+                sm.Id      AS FlcStructureMapId,
+                sm.Url     AS StructureMapUrl,
+                sm.Version AS StructureMapVersion,
+
+                l.Id       AS FlcLibraryId,
+                l.Url      AS LibraryUrl,
+                l.Version  AS LibraryVersion
+            FROM flcStructureMap sm
+            INNER JOIN flcImplementationGuide ig ON sm.FlcImplementationGuideId = ig.Id
+            INNER JOIN flcLibrary l              ON sm.FlcLibraryId = l.Id
+            WHERE sm.Id = @StructureMapId
+            LIMIT 1;
+        """;
+
+        using var connection = OpenConnection();
+        return await connection.QueryFirstOrDefaultAsync<ImplementationGuideStructureMapLibraryFlat>(
+            sql, new { StructureMapId = structureMapId });
+    }
+
+    /// <summary>
+    /// Get one StructureMap (filter on URL+Version) with ImplementationGuide and Library as flat model.
+    /// </summary>
+    /// <param name="url">StructureMap url</param>
+    /// <param name="version">StructureMap version</param>
+    public async Task<ImplementationGuideStructureMapLibraryFlat> GetFlatByUrlAndVersionAsync(string url, string version)
+    {
+        const string sql = """
+            SELECT 
+                ig.Id   AS FlcImplementationGuideId,
+                ig.Url  AS ImplementationGuideUrl,
+                ig.Version AS ImplementationGuideVersion,
+
+                sm.Id   AS FlcStructureMapId,
+                sm.Url  AS StructureMapUrl,
+                sm.Version AS StructureMapVersion,
+
+                l.Id    AS FlcLibraryId,
+                l.Url   AS LibraryUrl,
+                l.Version AS LibraryVersion
+            FROM flcStructureMap sm
+            INNER JOIN flcImplementationGuide ig ON sm.FlcImplementationGuideId = ig.Id
+            INNER JOIN flcLibrary l ON sm.FlcLibraryId = l.Id
+            WHERE sm.Url = @Url AND sm.Version = @Version            
+            LIMIT 1;
+        """;
+
+        using var connection = OpenConnection();
+        return await connection.QueryFirstOrDefaultAsync<ImplementationGuideStructureMapLibraryFlat>(
+            sql, new { Url = url, Version = version });
+    }
+
+    /// <summary>
+    /// Get all StructureMaps for an ImplementationGuide (Url+Version) with Libraries as flat list.
+    /// </summary>
+    public async Task<IReadOnlyList<ImplementationGuideStructureMapLibraryFlat>> GetAllFlatAsync()
+    {
+        const string sql = """
+            SELECT 
+                ig.Id   AS FlcImplementationGuideId,
+                ig.Url  AS ImplementationGuideUrl,
+                ig.Version AS ImplementationGuideVersion,
+
+                sm.Id   AS FlcStructureMapId,
+                sm.Url  AS StructureMapUrl,
+                sm.Version AS StructureMapVersion,
+
+                l.Id    AS FlcLibraryId,
+                l.Url   AS LibraryUrl,
+                l.Version AS LibraryVersion
+            FROM flcStructureMap sm
+            INNER JOIN flcLibrary l ON sm.FlcLibraryId = l.Id
+            INNER JOIN flcImplementationGuide ig ON sm.FlcImplementationGuideId = ig.Id
+            ORDER BY sm.Url, sm.Version
+        """;
+
+        using var connection = OpenConnection();
+
+        var rows = await connection.QueryAsync<ImplementationGuideStructureMapLibraryFlat>(sql);
+
+        return rows.ToList();
+    }
+
+    /// <summary>
+    /// Get all StructureMaps for an ImplementationGuide (Url+Version) with Libraries as flat list.
+    /// </summary>
+    /// <param name="implementationGuideUrl">ImplementationGuide url</param>
+    /// <param name="implementationGuideVersion">ImplementationGuide version</param>
+    public async Task<IReadOnlyList<ImplementationGuideStructureMapLibraryFlat>> GetFlatByImplementationGuideAsync(
+        string implementationGuideUrl, string implementationGuideVersion)
+    {
+        const string sql = """
+            SELECT 
+                ig.Id   AS FlcImplementationGuideId,
+                ig.Url  AS ImplementationGuideUrl,
+                ig.Version AS ImplementationGuideVersion,
+
+                sm.Id   AS FlcStructureMapId,
+                sm.Url  AS StructureMapUrl,
+                sm.Version AS StructureMapVersion,
+
+                l.Id    AS FlcLibraryId,
+                l.Url   AS LibraryUrl,
+                l.Version AS LibraryVersion
+            FROM flcStructureMap sm
+            INNER JOIN flcLibrary l ON sm.FlcLibraryId = l.Id
+            INNER JOIN flcImplementationGuide ig ON sm.FlcImplementationGuideId = ig.Id
+            WHERE ig.Url = @Url AND ig.Version = @Version
+            ORDER BY sm.Url, sm.Version
+        """;
+
+        using var connection = OpenConnection();
+
+        var rows = await connection.QueryAsync<ImplementationGuideStructureMapLibraryFlat>(
+            sql, new { Url = implementationGuideUrl, Version = implementationGuideVersion });
+
+        return rows.ToList();
+    }
+
+    /// <summary>
+    /// Retrieves StructureMap template information for the given StructureMap Id.
+    /// Joins FlcStructureMap with FlcLibrary to return template-related details.
+    /// </summary>
+    /// <param name="structureMapId">The Id of the StructureMap.</param>
+    /// <returns>A StructureMapTemplateInfo object containing mapping details, or null if not found.</returns>
+    public async Task<StructureMapTemplateInfo> GetTemplateInfoByStructureMapIdAsync(int structureMapId)
+    {
+        const string sql = """
+            SELECT 
+                sm.Id AS FlcStructureMapId,
+                sm.EntryTemplate AS EntryTemplate,
+                l.StorageRoot AS TemplatesRoot
+            FROM flcStructureMap sm
+            INNER JOIN flcLibrary l ON sm.FlcLibraryId = l.Id
+            WHERE sm.Id = @StructureMapId
+            LIMIT 1;
+        """;
+
+        using var connection = OpenConnection();
+
+        return await connection.QueryFirstOrDefaultAsync<StructureMapTemplateInfo>(
+            sql,
+            new { StructureMapId = structureMapId });
+    }
+}

--- a/src/FLC.PackageManagement.Persistence/Scripts/SQLServer/000_CreateDatabase.sql
+++ b/src/FLC.PackageManagement.Persistence/Scripts/SQLServer/000_CreateDatabase.sql
@@ -1,0 +1,5 @@
+IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'flc-transformer')
+BEGIN
+    CREATE DATABASE [flc-transformer] COLLATE SQL_Latin1_General_CP1_CI_AS;
+END
+GO

--- a/src/FLC.PackageManagement.Persistence/Scripts/SQLServer/001_CreateTables.sql
+++ b/src/FLC.PackageManagement.Persistence/Scripts/SQLServer/001_CreateTables.sql
@@ -1,0 +1,66 @@
+USE [flc-transformer];
+
+CREATE TABLE dbo.flcImplementationGuide (
+  id					INT IDENTITY(1,1) CONSTRAINT PK_flcImplementationGuide_Id PRIMARY KEY,
+  implementationGuideId	NVARCHAR(64)  NULL,
+  [url]					NVARCHAR(350) NOT NULL,
+  [version]				NVARCHAR(64)  NOT NULL,
+  packageId				NVARCHAR(64)  NOT NULL,
+  createdAt				DATETIME2(3)  NOT NULL,
+  updatedAt				DATETIME2(3)  NOT NULL,    
+  urlVersion			AS (CONVERT(NVARCHAR(415), url + N'|' + [version])) PERSISTED,
+  resourceJson			NVARCHAR(MAX) NULL,
+  CONSTRAINT CK_flcImplementationGuide_implementationGuideId_Chars CHECK ([implementationGuideId] IS NULL OR (LEN([implementationGuideId]) BETWEEN 1 AND 64 AND [implementationGuideId] NOT LIKE N'%[^-0-9A-Za-z.]%')),
+  CONSTRAINT CK_flcImplementationGuide_packageId_Chars CHECK (LEN(packageId) BETWEEN 1 AND 64 AND packageId NOT LIKE N'%[^-0-9A-Za-z.]%'),
+  CONSTRAINT CK_flcImplementationGuide_resourceJson_IsJson CHECK (resourceJson IS NULL OR ISJSON(resourceJson) = 1)
+);
+GO
+CREATE UNIQUE INDEX UX_flcImplementationGuide_Url_Version ON dbo.flcImplementationGuide (url, [version]);
+GO
+
+CREATE TABLE dbo.flcLibrary (
+  id                        INT IDENTITY(1,1) CONSTRAINT PK_flcLibrary_Id PRIMARY KEY,
+  libraryId					NVARCHAR(64) NULL,
+  [url]                     NVARCHAR(350) NOT NULL,
+  [version]                 NVARCHAR(64)  NOT NULL,
+  flcImplementationGuideId  INT NOT NULL CONSTRAINT FK_flcLibrary_flcImplementationGuideId REFERENCES dbo.flcImplementationGuide(id),
+  storageRoot               NVARCHAR(400) NULL,
+  checksum                  VARBINARY(32) NULL,
+  createdAt                 DATETIME2(3)  NOT NULL,
+  updatedAt					DATETIME2(3)  NOT NULL,    
+  urlVersion                AS (CONVERT(NVARCHAR(415), url + N'|' + [version])) PERSISTED,
+  resourceJson              NVARCHAR(MAX) NULL,
+  CONSTRAINT CK_flcLibrary_resourceJson_IsJson CHECK (resourceJson IS NULL OR ISJSON(resourceJson) = 1),  
+  CONSTRAINT CK_flcLibrary_libraryId_Chars CHECK ([libraryId] IS NULL OR (LEN([libraryId]) BETWEEN 1 AND 64 AND [libraryId] NOT LIKE N'%[^-0-9A-Za-z.]%'))
+);
+GO
+
+CREATE UNIQUE INDEX UX_flcLibrary_Url_Version ON dbo.flcLibrary (url, [version]);
+CREATE INDEX IX_flcLibrary_flcImplementationGuideId ON dbo.flcLibrary (flcImplementationGuideId);
+GO
+
+CREATE TABLE dbo.flcStructureMap (
+  id                        INT IDENTITY(1,1) CONSTRAINT PK_flcStructureMap_Id PRIMARY KEY,
+  structureMapId            NVARCHAR(64)  NULL,
+  [url]                     NVARCHAR(350) NOT NULL,
+  [version]                 NVARCHAR(64)  NOT NULL,
+  flcImplementationGuideId  INT NOT NULL CONSTRAINT FK_flcStructureMap_flcImplementationGuideId REFERENCES dbo.flcImplementationGuide(id),
+  [source]                  NVARCHAR(350) NULL,
+  sourceVersion             NVARCHAR(64)  NULL,
+  [target]                  NVARCHAR(350) NULL,
+  targetVersion             NVARCHAR(64)  NULL,
+  flcLibraryId              INT NOT NULL CONSTRAINT FK_flcStructureMap_flcLibraryId REFERENCES dbo.flcLibrary(id),
+  entryTemplate             NVARCHAR(200) NULL,
+  createdAt                 DATETIME2(3)  NOT NULL,
+  updatedAt                 DATETIME2(3)  NOT NULL,
+  urlVersion                AS (CONVERT(NVARCHAR(415), url + N'|' + [version])) PERSISTED,
+  resourceJson              NVARCHAR(MAX) NULL,
+  CONSTRAINT CK_flcStructureMap_resourceJson_IsJson CHECK (resourceJson IS NULL OR ISJSON(resourceJson) = 1),  
+  CONSTRAINT CK_flcStructureMap_structureMapId_Chars CHECK ([structureMapId] IS NULL OR (LEN([structureMapId]) BETWEEN 1 AND 64 AND [structureMapId] NOT LIKE N'%[^-0-9A-Za-z.]%'))
+);
+GO
+
+CREATE UNIQUE INDEX UX_flcStructureMap_Url_Version ON dbo.flcStructureMap (url, [version]);
+CREATE INDEX IX_flcStructureMap_flcImplementationGuideId ON dbo.flcStructureMap (flcImplementationGuideId);
+CREATE INDEX IX_flcStructureMap_flcLibraryId ON dbo.flcStructureMap(flcLibraryId)
+GO

--- a/src/FLC.PackageManagement.Persistence/Scripts/SQLite/001_CreateTables.sql
+++ b/src/FLC.PackageManagement.Persistence/Scripts/SQLite/001_CreateTables.sql
@@ -1,0 +1,73 @@
+CREATE TABLE IF NOT EXISTS flcImplementationGuide (
+  id					INTEGER PRIMARY KEY,
+  implementationGuideId	TEXT	NULL,
+  url					TEXT    NOT NULL,
+  version				TEXT    NOT NULL,
+  packageId				TEXT    NOT NULL,
+  createdAt				TEXT    NOT NULL,
+  updatedAt				TEXT    NOT NULL,
+  urlVersion			TEXT GENERATED ALWAYS AS (url || '|' || version) VIRTUAL,
+  resourceJson			TEXT    NULL,
+  CHECK (implementationGuideId IS NULL OR (length(implementationGuideId) between 1 and 64 and implementationGuideId NOT GLOB '*[^A-Za-z0-9.-]*')),
+  CHECK (length(packageId)  between 1 and 64 and packageId  NOT GLOB '*[^A-Za-z0-9.-]*'),
+  CHECK (resourceJson IS NULL OR json_valid(resourceJson)=1)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS UX_flcImplementationGuide_Url_Version ON flcImplementationGuide (url COLLATE NOCASE, version COLLATE NOCASE);
+
+CREATE TABLE IF NOT EXISTS flcLibrary (
+  id						INTEGER PRIMARY KEY AUTOINCREMENT,
+  libraryId					TEXT    NULL,
+  url						TEXT    NOT NULL,
+  version					TEXT    NOT NULL,
+  flcImplementationGuideId	INTEGER NOT NULL,
+  storageRoot				TEXT    NULL,
+  checksum					BLOB    NULL,
+  createdAt					TEXT    NOT NULL,
+  updatedAt					TEXT    NOT NULL,
+  urlVersion				TEXT GENERATED ALWAYS AS (url || '|' || version) VIRTUAL,
+  resourceJson				TEXT    NULL,
+  CHECK (libraryId IS NULL OR (length(libraryId) between 1 and 64 and libraryId NOT GLOB '*[^A-Za-z0-9.-]*')),
+  CHECK (resourceJson IS NULL OR json_valid(resourceJson)=1),
+  FOREIGN KEY (flcImplementationGuideId) REFERENCES flcImplementationGuide(id) ON DELETE NO ACTION
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS UX_flcLibrary_Url_Version ON flcLibrary (url COLLATE NOCASE, version COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS IX_flcLibrary_flcImplementationGuideId ON flcLibrary (flcImplementationGuideId);
+-- Make flcLibrary PK start on 1001
+-- Initialize AUTOINCREMENT starting point if not already present
+INSERT INTO sqlite_sequence (name, seq)
+SELECT 'flcLibrary', 1000
+WHERE NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'flcLibrary');
+
+CREATE TABLE IF NOT EXISTS flcStructureMap (
+  id						INTEGER PRIMARY KEY AUTOINCREMENT,
+  structureMapId			TEXT    NULL,
+  url						TEXT    NOT NULL,
+  version					TEXT    NOT NULL,
+  flcImplementationGuideId	INTEGER NOT NULL,
+  source					TEXT    NULL,
+  sourceVersion				TEXT    NULL,
+  target					TEXT    NULL,
+  targetVersion				TEXT    NULL,
+  flcLibraryId				INTEGER NOT NULL,
+  entryTemplate				TEXT    NULL,
+  createdAt					TEXT    NOT NULL,
+  updatedAt					TEXT    NOT NULL,
+  urlVersion				TEXT GENERATED ALWAYS AS (url || '|' || version) VIRTUAL,
+  resourceJson				TEXT    NULL,
+  CHECK (structureMapId IS NULL OR (length(structureMapId) between 1 and 64 and structureMapId NOT GLOB '*[^A-Za-z0-9.-]*')),
+  CHECK (resourceJson IS NULL OR json_valid(resourceJson)=1),
+  FOREIGN KEY (flcImplementationGuideId) REFERENCES flcImplementationGuide(id) ON DELETE NO ACTION,
+  FOREIGN KEY (flcLibraryId) REFERENCES flcLibrary(id) ON DELETE NO ACTION
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS UX_flcStructureMap_Ig_Url_Version ON flcStructureMap (url COLLATE NOCASE, version COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS IX_flcStructureMap_flcImplementationGuideId ON flcStructureMap (flcImplementationGuideId);
+CREATE INDEX IF NOT EXISTS IX_flcStructureMap_flcLibraryId ON flcStructureMap (flcLibraryId);
+
+-- Make flcStructureMap PK start on 20001
+-- Initialize AUTOINCREMENT starting point if not already present
+INSERT INTO sqlite_sequence (name, seq)
+SELECT 'flcStructureMap', 20000
+WHERE NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'flcStructureMap');

--- a/src/FLC.PackageManagement.Persistence/Services/PersistenceService.cs
+++ b/src/FLC.PackageManagement.Persistence/Services/PersistenceService.cs
@@ -1,0 +1,83 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Models;
+using FLC.PackageManagement.Persistence.Exceptions;
+using FLC.PackageManagement.Persistence.Interfaces;
+using FLC.PackageManagement.Persistence.Mappers;
+using FLC.PackageManagement.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace FLC.PackageManagement.Persistence.Services;
+
+public class PersistenceService(
+    IFlcImplementationGuideRepository implementationGuideRepository,
+    IFlcLibraryRepository libraryRepository,
+    IFlcStructureMapRepository structureMapRepository,
+    ILogger<PersistenceService> logger)
+    : IPersistenceService
+{
+    public async Task UpsertPackageToDatabase(PackageResult packageResult)
+    {
+        try
+        {
+            var igEntity = PackageToEntityMapper.MapToFlcImplementationGuide(packageResult);
+            var existingIg = await implementationGuideRepository.GetByUrlAndVersionAsync(igEntity.Url, igEntity.Version);
+            if (existingIg == null)
+            {
+                var igId = await implementationGuideRepository.InsertAsync(igEntity);
+                var libraryId = await libraryRepository.InsertAsync(PackageToEntityMapper.MapToFlcLibrary(packageResult, igId));
+
+                // TODO: If more than one Library will be used in the future, we somehow need to resolve which libraryId to use for each StructureMap.
+
+                await structureMapRepository.InsertAsync(PackageToEntityMapper.MapToFlcStructureMaps(packageResult, igId, libraryId));
+            }
+            else
+            {
+                // ToDo: Fix performance for update flow - only update when needed
+                int igId = existingIg.Id;
+                igEntity.Id = igId;
+                await implementationGuideRepository.UpdateAsync(igEntity);
+
+                var libraryEntity = PackageToEntityMapper.MapToFlcLibrary(packageResult, igId);
+                var existingLibrary = await libraryRepository.GetByUrlAndVersionAsync(libraryEntity.Url, libraryEntity.Version);
+                int libraryId;
+                if (existingLibrary == null)
+                {
+                    // New Library
+                    libraryId = await libraryRepository.InsertAsync(libraryEntity);
+                }
+                else
+                {
+                    // Update Library
+                    libraryId = existingLibrary.Id;
+                    libraryEntity.Id = libraryId;
+                    await libraryRepository.UpdateAsync(libraryEntity);
+                }
+
+                var structureMapEntities = PackageToEntityMapper.MapToFlcStructureMaps(packageResult, igId, libraryId);
+                foreach (var structureMapEntity in structureMapEntities)
+                {
+                    var existingStructureMap = await structureMapRepository.GetByUrlAndVersionAsync(structureMapEntity.Url, structureMapEntity.Version);
+                    if (existingStructureMap == null)
+                    {
+                        // New structure map
+                        await structureMapRepository.InsertAsync(structureMapEntity);
+                    }
+                    else
+                    {
+                        // Update structure map
+                        structureMapEntity.Id = existingStructureMap.Id;
+                        await structureMapRepository.UpdateAsync(structureMapEntity);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, $"Failed insert package into database.");
+            throw new DatabaseException(ex.Message, ex);
+        }
+    }
+}

--- a/src/FLC.PackageManagement/Extensions/JsonExtensions.cs
+++ b/src/FLC.PackageManagement/Extensions/JsonExtensions.cs
@@ -1,0 +1,77 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Text.Json;
+
+namespace FLC.PackageManagement.Extensions;
+
+public static class JsonExtensions
+{
+    public static bool TryParseAsJsonDocument(this string content, out JsonDocument document)
+    {
+        document = null;
+        try
+        {
+            document = JsonDocument.Parse(content);
+            return true;
+        }
+        catch (Exception e) when (
+            e is JsonException ||
+            e is ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    public static string GetRequiredString(this JsonElement root, string prop)
+    {
+        if (!root.TryGetProperty(prop, out var propValue) || propValue.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidDataException($"The JSON is missing the \"{prop}\" string property.");
+        }
+
+        var value = propValue.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException($"The property \"{prop}\" has invalid value: {value}");
+        }
+
+        return value;
+    }
+
+    public static string GetOptionalString(this JsonElement root, string prop)
+        => root.TryGetProperty(prop, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() : null;
+
+    public static IEnumerable<JsonElement> GetArrayOrEmpty(this JsonElement root, string prop)
+        => root.TryGetProperty(prop, out var value) && value.ValueKind == JsonValueKind.Array
+            ? value.EnumerateArray() : Array.Empty<JsonElement>();
+
+    public static string GetExtensionValue(this JsonElement obj, string extensionUrl)
+    {
+        foreach (var ext in obj.GetArrayOrEmpty("extension"))
+        {
+            if (ext.TryGetProperty("url", out var u) && u.ValueKind == JsonValueKind.String &&
+                string.Equals(u.GetString(), extensionUrl, StringComparison.Ordinal))
+            {
+                if (ext.TryGetProperty("valueString", out var vs) && vs.ValueKind == JsonValueKind.String)
+                {
+                    return vs.GetString();
+                }
+
+                if (ext.TryGetProperty("valueCanonical", out var vc) && vc.ValueKind == JsonValueKind.String)
+                {
+                    return vc.GetString();
+                }
+
+                if (ext.TryGetProperty("valueUri", out var vu) && vu.ValueKind == JsonValueKind.String)
+                {
+                    return vu.GetString();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FLC.PackageManagement/Extensions/PackageManagementServiceCollectionExtensions.cs
+++ b/src/FLC.PackageManagement/Extensions/PackageManagementServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Services;
+using FLC.PackageManagement.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FLC.PackageManagement.Extensions
+{
+    public static class PackageManagementServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers the core PackageManagement services required for extracting,
+        /// unpacking and loading FHIR packages to disk.
+        ///
+        /// A persistence implementation can be added via
+        /// <c>AddPackageManagementPersistence()</c> for database persistence of the FHIR package contents, including Implementation Guides, Libraries, and StructureMaps.
+        /// </summary>
+        /// <param name="services">The service collection to register PackageManagement services into.</param>
+        /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+        public static IServiceCollection AddPackageManagement(this IServiceCollection services)
+        {
+            services.AddScoped<IPackageService, PackageService>();
+            services.AddScoped<IExtractService, ExtractService>();
+            services.AddScoped<ILibraryService, LibraryService>();
+
+            // Always register a default NoOp-implementation of IPersistenceService.
+            // If a real persistence service is registered later it willbe used
+            services.AddSingleton<IPersistenceService, NoOpPersistenceService>();
+            return services;
+        }
+    }
+}

--- a/src/FLC.PackageManagement/FLC.PackageManagement.csproj
+++ b/src/FLC.PackageManagement/FLC.PackageManagement.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <NoWarn>SA1201;$(NoWarn)</NoWarn> <!-- Used version of style cop does not handle primary constructors -->
+  </PropertyGroup>
+  
+</Project>

--- a/src/FLC.PackageManagement/GlobalSuppressions.cs
+++ b/src/FLC.PackageManagement/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1010:Opening square brackets should be spaced correctly", Justification = "New bracket syntax is not supported.", Scope = "member", Target = "~M:FLC.PackageManagement.Services.ExtractService.ExtractPackage(System.IO.Stream,System.String,System.Threading.CancellationToken)~System.Threading.Tasks.Task{FLC.PackageManagement.Models.PackageResult}")]

--- a/src/FLC.PackageManagement/Models/PackageResult.cs
+++ b/src/FLC.PackageManagement/Models/PackageResult.cs
@@ -1,0 +1,48 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Models;
+
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+#pragma warning disable SA1513 // Closing brace should be followed by blank line
+public record PackageResult(
+    ImplementationGuideItem ImplementationGuideItem,
+    LibraryItem LibraryItem,
+    List<StructureMapItem> StructureMapItems);
+
+public record ImplementationGuideItem(
+    string Id,
+    string Url,
+    string Version,
+    string PackageId,
+    string Json);
+
+public record LibraryItem(
+    string Id,
+    string Url,
+    string Version,
+    string StorageRoot,
+    string Json)
+{
+    public static LibraryItem CreateFrom(LibraryItem src, string storageRoot)
+        => src with { StorageRoot = storageRoot };
+};
+
+public record StructureMapItem(
+    string Id,
+    string Url,
+    string Version,
+    string Source,
+    string SourceVersion,
+    string Target,
+    string TargetVersion,
+    string EntryTemplate,
+    string Json)
+{
+    public static StructureMapItem CreateFrom(StructureMapItem src, string entryTemplate)
+        => src with { EntryTemplate = entryTemplate };
+};
+
+#pragma warning restore SA1313
+#pragma warning restore SA1513

--- a/src/FLC.PackageManagement/Models/SequentialStream.cs
+++ b/src/FLC.PackageManagement/Models/SequentialStream.cs
@@ -1,0 +1,176 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Models;
+
+public sealed class SequentialStream : Stream
+{
+    private readonly Stream _first;
+    private readonly Stream _second;
+    private readonly bool _leaveOpen;
+    private bool _firstExhausted = false;
+
+    public SequentialStream(Stream first, Stream second, bool leaveOpen = false)
+    {
+        _first = first ?? throw new ArgumentNullException(nameof(first));
+        _second = second ?? throw new ArgumentNullException(nameof(second));
+        _leaveOpen = leaveOpen;
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        if ((uint)offset > buffer.Length || (uint)count > buffer.Length - offset)
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+
+        if (buffer.Length == 0 || count == 0)
+        {
+            return 0;
+        }
+
+        if (!_firstExhausted)
+        {
+            int read = _first.Read(buffer, offset, count);
+            if (read > 0)
+            {
+                return read;
+            }
+
+            _firstExhausted = true;
+        }
+
+        return _second.Read(buffer, offset, count);
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        if (buffer.Length == 0)
+        {
+            return 0;
+        }
+
+        if (!_firstExhausted)
+        {
+            int read = _first.Read(buffer);
+            if (read > 0)
+            {
+                return read;
+            }
+
+            _firstExhausted = true;
+        }
+
+        return _second.Read(buffer);
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        if ((uint)offset > buffer.Length || (uint)count > buffer.Length - offset)
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+
+        if (buffer.Length == 0 || count == 0)
+        {
+            return 0;
+        }
+
+        if (!_firstExhausted)
+        {
+            int read = await _first.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            if (read > 0)
+            {
+                return read;
+            }
+
+            _firstExhausted = true;
+        }
+
+        return await _second.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (buffer.Length == 0)
+        {
+            return 0;
+        }
+
+        if (!_firstExhausted)
+        {
+            int read = await _first.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read > 0)
+            {
+                return read;
+            }
+
+            _firstExhausted = true;
+        }
+
+        return await _second.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override int ReadByte()
+    {
+        if (!_firstExhausted)
+        {
+            int read = _first.ReadByte();
+            if (read > 0)
+            {
+                return read;
+            }
+
+            _firstExhausted = true;
+        }
+
+        return _second.ReadByte();
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_leaveOpen)
+        {
+            _first.Dispose();
+            _second.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (!_leaveOpen)
+        {
+            await _first.DisposeAsync().ConfigureAwait(false);
+            await _second.DisposeAsync().ConfigureAwait(false);
+        }
+
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/FLC.PackageManagement/Services/ExtractService.cs
+++ b/src/FLC.PackageManagement/Services/ExtractService.cs
@@ -1,0 +1,189 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Text.Json;
+using FLC.PackageManagement.Extensions;
+using FLC.PackageManagement.Models;
+using FLC.PackageManagement.Services.Interfaces;
+
+namespace FLC.PackageManagement.Services;
+
+public class ExtractService : IExtractService
+{
+    public async Task<PackageResult> ExtractPackage(Stream stream, string igFoldersRootPath, CancellationToken cancellationToken)
+    {
+        byte[] streamBuffer = new byte[3];
+        stream.ReadExactly(streamBuffer, 0, streamBuffer.Length);
+
+        // identifier bytes for gzip
+        if (streamBuffer[0] != 31 || streamBuffer[1] != 139 || streamBuffer[2] != 8)
+        {
+            throw new InvalidDataException("Stream doesn't contain a .gzip");
+        }
+
+        await using var readMemoryStream = new MemoryStream(streamBuffer);
+        await using var sequentialStream = new SequentialStream(readMemoryStream, stream);
+        await using var gzipStream = new GZipStream(sequentialStream, CompressionMode.Decompress, leaveOpen: true);
+
+        // 512 is the headersize for a .tar file
+        byte[] gzipStreamBuffer = new byte[512];
+        try
+        {
+            gzipStream.ReadExactly(gzipStreamBuffer, 0, gzipStreamBuffer.Length);
+        }
+        catch (EndOfStreamException)
+        {
+            // the underlying file can't have a complete header
+            throw new InvalidDataException("The underlying file in the gzip isn't a .tar");
+        }
+
+        // checks the header for if the .tar file follows the UStar format
+        // which is almost a guarantee which i'll use as a validation point
+        if (gzipStreamBuffer[257] != (byte)'u'
+            || gzipStreamBuffer[258] != (byte)'s'
+            || gzipStreamBuffer[259] != (byte)'t'
+            || gzipStreamBuffer[260] != (byte)'a'
+            || gzipStreamBuffer[261] != (byte)'r')
+        {
+            throw new InvalidDataException("The underlying file in the gzip isn't a .tar");
+        }
+
+        await using var readGzipMemoryStream = new MemoryStream(gzipStreamBuffer);
+        await using var gzipSequentialStream = new SequentialStream(readGzipMemoryStream, gzipStream);
+        await using var tarReader = new TarReader(gzipSequentialStream);
+        ImplementationGuideItem igItem = null;
+        LibraryItem libraryItem = null;
+        var structureMapItems = new List<StructureMapItem>();
+
+        TarEntry entry;
+        while ((entry = tarReader.GetNextEntry()) != null)
+        {
+            if (entry.EntryType != TarEntryType.RegularFile)
+            {
+                continue;
+            }
+
+            string fileName = Path.GetFileName(entry.Name);
+
+            using var sr = new StreamReader(entry.DataStream, leaveOpen: true);
+            var content = await sr.ReadToEndAsync(cancellationToken);
+
+            if (!content.TryParseAsJsonDocument(out var jsonDocument))
+            {
+                continue;
+            }
+
+            var root = jsonDocument.RootElement;
+
+            switch (fileName)
+            {
+                case var s when s.StartsWith("ImplementationGuide", StringComparison.OrdinalIgnoreCase):
+                    igItem = new ImplementationGuideItem(
+                        root.GetOptionalString("id"),
+                        root.GetRequiredString("url"),
+                        root.GetRequiredString("version"),
+                        root.GetRequiredString("packageId"),
+                        content);
+                    break;
+                case var s when s.StartsWith("Library", StringComparison.OrdinalIgnoreCase):
+                    libraryItem = new LibraryItem(
+                        root.GetRequiredString("id"),
+                        root.GetRequiredString("url"),
+                        root.GetRequiredString("version"),
+                        null, // StorageRoot will be set later
+                        content);
+                    break;
+                case var s when s.StartsWith("StructureMap", StringComparison.OrdinalIgnoreCase):
+
+                    string liquidTemplate = root.GetArrayOrEmpty("group")
+                        .SelectMany(g => g.GetArrayOrEmpty("rule"))
+                        .SelectMany(r => r.GetArrayOrEmpty("target"))
+                        .SelectMany(t => t.GetArrayOrEmpty("extension"))
+                        .Select(e => e.GetExtensionValue("liquidTemplate"))
+                        .FirstOrDefault(v => v != null);
+
+                    structureMapItems.Add(new StructureMapItem(
+                        root.GetOptionalString("id"),
+                        root.GetRequiredString("url"),
+                        root.GetRequiredString("version"),
+                        root.GetOptionalString("source"),
+                        root.GetOptionalString("sourceVersion"),
+                        root.GetOptionalString("target"),
+                        root.GetOptionalString("targetVersion"),
+                        liquidTemplate,
+                        content));
+                    break;
+                default:
+                    break;
+            }
+
+            jsonDocument.Dispose();
+        }
+
+        if (igItem is null)
+        {
+            throw new InvalidDataException("No implementationGuide file present");
+        }
+
+        var entryTemplates = structureMapItems.Select(sm => sm.EntryTemplate);
+        if (!entryTemplates.Any())
+        {
+            throw new InvalidOperationException("No EntryTemplate available.");
+        }
+
+        // Some post processing is required for applying StorageRoot. We need data from IG and StructureMap, which may not be available ehen LibraryItem was created.
+        var libraryRoot = JsonDocument.Parse(libraryItem.Json).RootElement;
+
+        // TODO: We currently assume that all StructureMaps have the same folder paths, so we just take the first one.
+        var entryTemplateFolder = FindFolderPathByLogicalFilename(libraryRoot, entryTemplates.FirstOrDefault());
+
+        if (string.IsNullOrWhiteSpace(entryTemplateFolder))
+        {
+            throw new InvalidDataException("No folder path available for entry template.");
+        }
+
+        libraryItem = LibraryItem.CreateFrom(
+            libraryItem,
+            Path.Combine(igFoldersRootPath, igItem.PackageId, igItem.Version, libraryItem.Id, entryTemplateFolder));
+
+        structureMapItems = [.. structureMapItems.Select(sm => StructureMapItem.CreateFrom(sm, Path.GetFileNameWithoutExtension(sm.EntryTemplate)))];
+
+        return new PackageResult(
+            ImplementationGuideItem: igItem,
+            LibraryItem: libraryItem,
+            StructureMapItems: structureMapItems);
+    }
+
+    public static string FindFolderPathByLogicalFilename(JsonElement libraryRoot, string logicalFilename)
+    {
+        return libraryRoot.GetArrayOrEmpty("content")
+            .SelectMany(c => c.GetArrayOrEmpty("extension"))
+            .Select(ext => ext.GetArrayOrEmpty("extension").ToArray())
+            .Select(inner =>
+            {
+                bool matches = inner.Any(e =>
+                    e.TryGetProperty("url", out var u) && u.ValueKind == JsonValueKind.String &&
+                    string.Equals(u.GetString(), "logical-filename", StringComparison.OrdinalIgnoreCase) &&
+                    e.TryGetProperty("valueString", out var v) && v.ValueKind == JsonValueKind.String &&
+                    string.Equals(v.GetString(), logicalFilename, StringComparison.OrdinalIgnoreCase));
+
+                if (!matches)
+                {
+                    return null;
+                }
+
+                var folder = inner.FirstOrDefault(e =>
+                    e.TryGetProperty("url", out var u) && u.ValueKind == JsonValueKind.String &&
+                    string.Equals(u.GetString(), "folder-path", StringComparison.OrdinalIgnoreCase) &&
+                    e.TryGetProperty("valueString", out var v) && v.ValueKind == JsonValueKind.String);
+
+                return folder.ValueKind == JsonValueKind.Object
+                    ? folder.GetProperty("valueString").GetString()
+                    : null;
+            })
+            .FirstOrDefault(v => v != null);
+    }
+}

--- a/src/FLC.PackageManagement/Services/Interfaces/IExtractService.cs
+++ b/src/FLC.PackageManagement/Services/Interfaces/IExtractService.cs
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Models;
+
+namespace FLC.PackageManagement.Services.Interfaces;
+
+public interface IExtractService
+{
+    Task<PackageResult> ExtractPackage(Stream stream, string igFoldersRootPath, CancellationToken cancellationToken = default);
+}

--- a/src/FLC.PackageManagement/Services/Interfaces/ILibraryService.cs
+++ b/src/FLC.PackageManagement/Services/Interfaces/ILibraryService.cs
@@ -1,0 +1,10 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Services.Interfaces;
+
+public interface ILibraryService
+{
+    Task<string> Unpack(string basePath, string libraryjson);
+}

--- a/src/FLC.PackageManagement/Services/Interfaces/IPackageService.cs
+++ b/src/FLC.PackageManagement/Services/Interfaces/IPackageService.cs
@@ -1,0 +1,10 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+namespace FLC.PackageManagement.Services.Interfaces;
+
+public interface IPackageService
+{
+    Task LoadPackage(Stream stream, bool allowPackageOverwrite, string fhirPackagesRootPath, CancellationToken cancellationToken = default);
+}

--- a/src/FLC.PackageManagement/Services/Interfaces/IPersistenceService.cs
+++ b/src/FLC.PackageManagement/Services/Interfaces/IPersistenceService.cs
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Models;
+
+namespace FLC.PackageManagement.Services.Interfaces;
+
+public interface IPersistenceService
+{
+    Task UpsertPackageToDatabase(PackageResult packageResult);
+}

--- a/src/FLC.PackageManagement/Services/LibraryService.cs
+++ b/src/FLC.PackageManagement/Services/LibraryService.cs
@@ -1,0 +1,134 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.Text;
+using System.Text.Json;
+using FLC.PackageManagement.Extensions;
+using FLC.PackageManagement.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace FLC.PackageManagement.Services
+{
+    public class LibraryService : ILibraryService
+    {
+        private readonly ILogger<LibraryService> _logger;
+
+        public LibraryService(ILogger<LibraryService> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<string> Unpack(string basePath, string libraryjson)
+        {
+            var jsonDocument = JsonDocument.Parse(libraryjson);
+            var content = jsonDocument.RootElement.GetProperty("content");
+
+            var specList = content.EnumerateArray().Select(ToFileSpec);
+
+            var duplicate = specList.GroupBy(x => x.FolderPath + x.FileName).FirstOrDefault(x => x.Count() != 1);
+            if (duplicate is not null)
+            {
+                throw new JsonException($"Duplicate file entry found: folder-path = '{duplicate.First().FolderPath}', logical-filename = '{duplicate.First().FileName}'");
+            }
+
+            var fileTasks = new List<Task>();
+            foreach (var spec in specList)
+            {
+                byte[] data = Convert.FromBase64String(spec.Data);
+                var dataAsText = Encoding.UTF8.GetString(data);
+
+                string newFolderPath = Path.Combine(basePath, spec.FolderPath);
+                Directory.CreateDirectory(newFolderPath);
+
+                _logger.LogInformation("Created Folder: {newFolderPath}", newFolderPath);
+
+                var completeFilePath = Path.Combine(newFolderPath, spec.FileName);
+                fileTasks.Add(WriteToFileWithLog(completeFilePath, dataAsText));
+            }
+
+            await Task.WhenAll(fileTasks);
+
+            return basePath;
+        }
+
+        private FileSpec ToFileSpec(JsonElement jsonElement, int index)
+        {
+            var outerExt = jsonElement.GetArrayOrEmpty("extension");
+            if (outerExt.Count() != 1)
+            {
+                throw new JsonException(
+                    $"expected exactly one item in extension for file {index}",
+                    $"$.content[{index}].extension",
+                    lineNumber: null,
+                    bytePositionInLine: null);
+            }
+
+            var inner = outerExt.First().GetArrayOrEmpty("extension");
+            if (!inner.Any())
+            {
+                throw new JsonException(
+                    $"missing nested extension array for file {index}",
+                    $"$.content[{index}].extension[0].extension",
+                    lineNumber: null,
+                    bytePositionInLine: null);
+            }
+
+            string fileName = null;
+            string folderPath = null;
+
+            foreach (var ext in inner)
+            {
+                var url = ext.GetOptionalString("url");
+                if (string.Equals(url, "logical-filename", StringComparison.OrdinalIgnoreCase))
+                {
+                    fileName = ext.GetOptionalString("valueString");
+                }
+                else if (string.Equals(url, "folder-path", StringComparison.OrdinalIgnoreCase))
+                {
+                    folderPath = ext.GetOptionalString("valueString");
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new JsonException(
+                    $"logical-filename is missing from file number: {index}",
+                    $"$.content[{index}].extension[0].extension[?(@.url==\"logical-filename\")].valueString",
+                    lineNumber: null,
+                    bytePositionInLine: null);
+            }
+
+            if (string.IsNullOrWhiteSpace(folderPath))
+            {
+                throw new JsonException(
+                    $"folder-path is missing from file number: {index}",
+                    $"$.content[{index}].extension[0].extension[?(@.url==\"folder-path\")].valueString",
+                    lineNumber: null,
+                    bytePositionInLine: null);
+            }
+
+            var dataEl = jsonElement.GetOptionalString("data");
+            if (string.IsNullOrWhiteSpace(dataEl))
+            {
+                throw new JsonException(
+                    $"data is missing from file number: {index}",
+                    $"$.content[{index}].data",
+                    lineNumber: null,
+                    bytePositionInLine: null);
+            }
+
+            return new FileSpec(fileName!, folderPath!, dataEl);
+        }
+
+        private async Task WriteToFileWithLog(string path, string content)
+        {
+            await File.WriteAllTextAsync(path, content);
+            _logger.LogInformation("Created file: {path}", path);
+        }
+
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+        private sealed record FileSpec(string FileName, string FolderPath, string Data);
+#pragma warning restore SA1313
+    }
+}

--- a/src/FLC.PackageManagement/Services/NoOpPersistenceService.cs
+++ b/src/FLC.PackageManagement/Services/NoOpPersistenceService.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Models;
+using FLC.PackageManagement.Services.Interfaces;
+
+namespace FLC.PackageManagement.Services;
+
+public class NoOpPersistenceService : IPersistenceService
+{
+    public Task UpsertPackageToDatabase(PackageResult packageResult)
+    {
+        // Empty to ignore persistence when not activated
+        return Task.CompletedTask;
+    }
+}

--- a/src/FLC.PackageManagement/Services/PackageService.cs
+++ b/src/FLC.PackageManagement/Services/PackageService.cs
@@ -1,0 +1,50 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using FLC.PackageManagement.Services.Interfaces;
+
+namespace FLC.PackageManagement.Services;
+
+public class PackageService(
+    IExtractService extractService,
+    ILibraryService libraryService,
+    IPersistenceService persistenceService)
+    : IPackageService
+{
+    public async Task LoadPackage(Stream stream, bool allowPackageOverwrite, string fhirPackagesRootPath, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fhirPackagesRootPath, "fhirPackagesRoot is missing or not set.");
+        var packageResult = await extractService.ExtractPackage(stream, fhirPackagesRootPath, cancellationToken);
+
+        var igFolderPath = Path.Combine(
+            fhirPackagesRootPath,
+            packageResult.ImplementationGuideItem.PackageId,
+            packageResult.ImplementationGuideItem.Version);
+
+        if (Directory.Exists(igFolderPath))
+        {
+            if (!allowPackageOverwrite)
+            {
+                throw new InvalidOperationException($"ImplementationGuide already exists for packageId:\"{packageResult.ImplementationGuideItem.PackageId}\", version:\"{packageResult.ImplementationGuideItem.Version}\". Use parameter '-o true' for allowOverwrite=true to force overwriting.");
+            }
+            else
+            {
+                // Recursively delete existing folder when overwrite is allowed
+                Directory.Delete(igFolderPath, recursive: true);
+
+                // Re-create folder so we start clean
+                Directory.CreateDirectory(igFolderPath);
+            }
+        }
+        else
+        {
+            Directory.CreateDirectory(igFolderPath);
+        }
+
+        var libraryRootFolderPath = Path.Combine(igFolderPath, packageResult.LibraryItem.Id);
+        await libraryService.Unpack(libraryRootFolderPath, packageResult.LibraryItem.Json);
+
+        await persistenceService.UpsertPackageToDatabase(packageResult);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Configuration/ConfigurationHelper.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Configuration/ConfigurationHelper.cs
@@ -1,0 +1,60 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Tool.Configuration;
+
+public static class ConfigurationHelper
+{
+    /// <summary>
+    /// Builds a configuration object using:
+    /// - appsettings.json
+    /// - appsettings.{Environment}.json
+    /// - environment variables
+    /// If the "PackageManagement" section is missing completely,
+    /// default values will be injected automatically.
+    /// </summary>
+    /// <param name="environmentVariableName">
+    /// Name of the environment variable that holds the environment name.
+    /// Default is DOTNET_ENVIRONMENT.
+    /// </param>
+    public static IConfiguration BuildConfiguration(string environmentVariableName = "DOTNET_ENVIRONMENT")
+    {
+        var environment = Environment.GetEnvironmentVariable(environmentVariableName);
+
+        // Step 1: load base config (json + env)
+        var baseConfig = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+            .AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: false)
+            .AddEnvironmentVariables()
+            .Build();
+
+        // Step 2: detect if ANY PackageManagement entries exist
+        bool hasPackageManagementConfig =
+            baseConfig.GetSection("PackageManagement").Exists() &&
+            baseConfig.GetSection("PackageManagement").GetChildren().Any();
+
+        if (hasPackageManagementConfig)
+        {
+            return baseConfig; // Use user-supplied config as-is
+        }
+
+        // Step 3: inject fallback defaults because section is missing entirely
+        var defaultValues = new Dictionary<string, string>
+        {
+            ["PackageManagement:Database:Provider"] = "SQLite",
+            ["PackageManagement:Database:InitializeAtStartup"] = "true",
+            ["PackageManagement:ConnectionStrings:SQLite"] = "Data Source=./database/flc-transformer.db;Cache=Shared;Foreign Keys=True",
+        };
+
+        return new ConfigurationBuilder()
+            .AddConfiguration(baseConfig)
+            .AddInMemoryCollection(defaultValues) // fallback config
+            .Build();
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
@@ -20,10 +20,13 @@
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FLC.PackageManagement\FLC.PackageManagement.csproj" />
+    <ProjectReference Include="..\FLC.PackageManagement.Persistence\FLC.PackageManagement.Persistence.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.Liquid.Converter\Microsoft.Health.Fhir.Liquid.Converter.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.TemplateManagement\Microsoft.Health.Fhir.TemplateManagement.csproj" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Models/PackageManagementOptions.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Models/PackageManagementOptions.cs
@@ -1,0 +1,24 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using CommandLine;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Tool.Models;
+
+// Sample: Microsoft.Health.Fhir.Liquid.Converter.Tool import-package C:\Data\Import\package_251127_01.tgz -d C:\Data\PackageRoot -o false
+[Verb("import-package", HelpText = "Import a FHIR package (.tgz) into the local package store")]
+public sealed class PackageManagementOptions
+{
+    [Value(0, MetaName = "FhirPackagePath", Required = true, HelpText = "Path to the FHIR package (.tgz) file to import")]
+    public string InputFhirPackageFilePath { get; set; } = string.Empty;
+
+    [Option('d', "FhirPackagesDirectory", Required = true, HelpText = "Root directory where FHIR packages will be extracted")]
+    public string FhirPackagesRootPath { get; set; } = string.Empty;
+
+    [Option('o', "AllowOverwrite", Required = false, HelpText = "Allow overwriting an existing ImplementationGuide folder (same packageId + version). Default: false.")]
+    public bool? AllowPackageOverwrite { get; set; }
+
+    [Option('p', "UsePersistence", Required = false, HelpText = "Use sqllite database persistence for package meta when importing the FHIR package. Default: true.")]
+    public bool? UsePersistence { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/PackageManagementLogicHandler.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/PackageManagementLogicHandler.cs
@@ -1,0 +1,77 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Service Well AB.
+// Modifications licensed under the Apache License, Version 2.0. See LICENSE in the repo root.
+// -------------------------------------------------------------------------------------------------
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FLC.PackageManagement.Extensions;
+using FLC.PackageManagement.Persistence.Extensions;
+using FLC.PackageManagement.Persistence.Initialization;
+using FLC.PackageManagement.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Liquid.Converter.Tool.Configuration;
+using Microsoft.Health.Fhir.Liquid.Converter.Tool.Models;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Tool;
+
+internal static class PackageManagementLogicHandler
+{
+    internal static async Task ImportPackageAsync(PackageManagementOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.InputFhirPackageFilePath))
+        {
+            throw new InputParameterException("Input FHIR package file path is required.");
+        }
+
+        if (!File.Exists(options.InputFhirPackageFilePath))
+        {
+            throw new InputParameterException($"Input FHIR package file '{options.InputFhirPackageFilePath}' does not exist.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.FhirPackagesRootPath))
+        {
+            throw new InputParameterException("FhirPackagesRootPath is required.");
+        }
+
+        // Load appsettings and persistence default values
+        var configuration = ConfigurationHelper.BuildConfiguration();
+
+        var usePersistence = options.UsePersistence ?? true;
+        var allowOverwrite = options.AllowPackageOverwrite ?? false;
+
+        // Build a service provider with PackageManagement
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddConsole());
+        services.AddPackageManagement();
+
+        if (usePersistence)
+        {
+            services.AddPackageManagementPersistence(configuration);
+        }
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        if (usePersistence)
+        {
+            var contentRootPath = Directory.GetCurrentDirectory();
+            SqliteDatabaseFileHelper.EnsureSqliteFolder(configuration, contentRootPath);
+            var dbInitializer = serviceProvider.GetService<IDatabaseInitializer>();
+            if (dbInitializer is not null)
+            {
+                await dbInitializer.InitializeAsync(CancellationToken.None);
+            }
+        }
+
+        var packageService = serviceProvider.GetRequiredService<IPackageService>();
+
+        await using var stream = File.OpenRead(options.InputFhirPackageFilePath);
+
+        await packageService.LoadPackage(
+                stream,
+                allowOverwrite,
+                options.FhirPackagesRootPath,
+                CancellationToken.None);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Program.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Program.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 //
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using CommandLine;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Health.Fhir.Liquid.Converter.Tool.Configuration;
 using Microsoft.Health.Fhir.Liquid.Converter.Tool.Models;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
@@ -29,12 +30,13 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
                 Console.ReadLine();
             }
 #endif
-            var parseResult = Parser.Default.ParseArguments<ConverterOptions, PullTemplateOptions, PushTemplateOptions>(args);
+            var parseResult = Parser.Default.ParseArguments<ConverterOptions, PullTemplateOptions, PushTemplateOptions, PackageManagementOptions>(args);
             try
             {
                 parseResult.WithParsed<ConverterOptions>(ConverterLogicHandler.Convert);
                 await parseResult.WithParsedAsync<PullTemplateOptions>(TemplateManagementLogicHandler.PullAsync);
                 await parseResult.WithParsedAsync<PushTemplateOptions>(TemplateManagementLogicHandler.PushAsync);
+                await parseResult.WithParsedAsync<PackageManagementOptions>(PackageManagementLogicHandler.ImportPackageAsync);
                 parseResult.WithNotParsed(HandleOptionsParseError);
                 return 0;
             }
@@ -47,14 +49,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
 
         private static AppSettings GetAppSettings()
         {
-            var environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
-
-            IConfiguration configuration = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
-                .AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: false)
-                .AddEnvironmentVariables()
-                .Build();
-
+            var configuration = ConfigurationHelper.BuildConfiguration();
             return configuration.Get<AppSettings>();
         }
 


### PR DESCRIPTION
# Add Fhir package management support and optional persistence to CLI and core libraries

This PR introduces the new **FLC.PackageManagement** and **FLC.PackageManagement.Persistence** libraries and adds package-management capabilities to the command-line tooling.

## Key Additions

- Implemented full **FHIR package extraction**  
  (`ExtractService`, `LibraryService`, `PackageService`) for handling `.tgz` packages.
- Added **optional database persistence** (SQLite) with automatic fallback to a No-Op provider when not configured.
- Introduced **default PackageManagement configuration values** for scenarios where no appsettings/environment configuration exists.
- Extended the CLI with a new **`import-package`** verb that:
  - reads a `.tgz` FHIR package,
  - extracts ImplementationGuide and Library content into a target root folder,
  - supports overwrite control (`--AllowOverwrite`),
  - optionally enables persistence.
- Added **SQLite database initialization logic** for both API hosting and CLI execution.

## Notes

- No breaking changes to existing template-management commands.
