### PR TITLE
Ensure output file safety and validate FHIR cache directory

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
@@ -67,6 +67,13 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
             ConverterResult result = null;
             string rawResultString = null;
 
+            // To make sure that if an error occurs during conversion and
+            // doesn't overwrite the previous successful output, we wont confuse it with a successful conversion.
+            if (File.Exists(outputFile))
+            {
+                File.Delete(outputFile);
+            }
+
             try
             {
                 // We get raw output – can be json or xml

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Validators/ProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Validators/ProfileValidator.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.IO;
 using System.Linq;
 using Firely.Fhir.Packages;
 using Hl7.Fhir.Specification.Source;
@@ -46,7 +47,14 @@ public static class ProfileValidator
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        var cacheKey = fhirCacheDirectory ?? Platform.GetFhirPackageRoot();
+        var cacheKey = string.IsNullOrWhiteSpace(fhirCacheDirectory)
+            ? Platform.GetFhirPackageRoot()
+            : fhirCacheDirectory;
+
+        if (!Directory.Exists(cacheKey))
+        {
+            throw new DirectoryNotFoundException($"The specified FHIR cache directory does not exist: {cacheKey}");
+        }
 
         var validator = _validatorCache.GetOrAdd(cacheKey, CreateValidator);
 


### PR DESCRIPTION
Add logic to delete existing output file before conversion to prevent confusion with previous results. Validate FHIR cache directory existence in ProfileValidator and clarify cache key selection to avoid runtime errors.